### PR TITLE
feature/not use fw messaging in cs

### DIFF
--- a/src/background/messages/forwarder.ts
+++ b/src/background/messages/forwarder.ts
@@ -17,9 +17,7 @@ const handler: PlasmoMessaging.MessageHandler<
   if (req.body?.action === "Subscribe") {
     await sendToContentScript({
       name: "Subscribe",
-      body: {
-        comments: req.body.comments || []
-      },
+      body: req.body,
       tabId: status?.comment_handler?.tabId
     }).catch((e) => {
       console.warn(e)
@@ -29,9 +27,7 @@ const handler: PlasmoMessaging.MessageHandler<
   if (req.body?.action === "SakuraComment") {
     await sendToContentScript({
       name: "SakuraComment",
-      body: {
-        comment: req.body.comment || ""
-      },
+      body: req.body,
       tabId: status?.selfpost_handler?.tabId
     }).catch((e) => {
       console.warn(e)

--- a/src/background/messages/forwarder.ts
+++ b/src/background/messages/forwarder.ts
@@ -16,9 +16,11 @@ const handler: PlasmoMessaging.MessageHandler<
 
   if (req.body?.action === "Subscribe") {
     await sendToContentScript({
-      action: "Subscribe",
-      tabId: status?.comment_handler?.tabId,
-      comments: req.body.comments
+      name: "Subscribe",
+      body: {
+        comments: req.body.comments || []
+      },
+      tabId: status?.comment_handler?.tabId
     }).catch((e) => {
       console.warn(e)
       res.send({ error: e })
@@ -26,9 +28,11 @@ const handler: PlasmoMessaging.MessageHandler<
   }
   if (req.body?.action === "SakuraComment") {
     await sendToContentScript({
-      action: "SakuraComment",
-      tabId: status?.selfpost_handler?.tabId,
-      comment: req.body.comment
+      name: "SakuraComment",
+      body: {
+        comment: req.body.comment || ""
+      },
+      tabId: status?.selfpost_handler?.tabId
     }).catch((e) => {
       console.warn(e)
       res.send({ error: e })

--- a/src/contents/example.ts
+++ b/src/contents/example.ts
@@ -8,7 +8,7 @@ import { batchInitialize } from "~src/lib/initializer"
 import { subscribePageNumber } from "~src/lib/poster"
 import { render } from "~src/lib/streamer"
 import { defaultConfig } from "~src/options"
-import { isLoadParams, isSubscribeParams } from "~src/types/guards"
+import { hasLoadParams, hasSubscribeParams } from "~src/types/guards"
 import {
   Config,
   ContentRequestBody,
@@ -32,7 +32,7 @@ const initialHandler = async (
   const storage = new Storage({ area: "local" })
   const config = (await storage.get<Config>("config")) || defaultConfig
 
-  if (isLoadParams(message)) {
+  if (hasLoadParams(message)) {
     const boxElement = exampleExtractor.boxElementFn()
     if (boxElement === null || boxElement === undefined) {
       sendResponse({ error: "Please start in presentation mode." })
@@ -81,14 +81,14 @@ const initialHandler = async (
     }
   }
 
-  if (isSubscribeParams(message)) {
+  if (hasSubscribeParams(message)) {
     const boxElement = exampleExtractor.boxElementFn()
     if (boxElement === null || boxElement === undefined) {
       sendResponse({ error: "Not found slide element..." })
       return
     }
 
-    render(boxElement, config, message.comments)
+    render(boxElement, config, message.body?.comments || [])
     sendResponse({ message: "comments rendered" })
   }
 }

--- a/src/contents/example.ts
+++ b/src/contents/example.ts
@@ -1,6 +1,7 @@
 import type { PlasmoCSConfig } from "plasmo"
 
-import { sendToBackground } from "@plasmohq/messaging"
+import { PlasmoMessaging, sendToBackground } from "@plasmohq/messaging"
+import { listen } from "@plasmohq/messaging/message"
 import { Storage } from "@plasmohq/storage"
 
 import { exampleExtractor } from "~src/lib/extractor/example"
@@ -9,12 +10,7 @@ import { subscribePageNumber } from "~src/lib/poster"
 import { render } from "~src/lib/streamer"
 import { defaultConfig } from "~src/options"
 import { hasLoadParams, hasSubscribeParams } from "~src/types/guards"
-import {
-  Config,
-  ContentRequestBody,
-  StreamerContentParams,
-  WorkerResponseBody
-} from "~src/types/types"
+import { Config, WorkerResponseBody } from "~src/types/types"
 
 export const config: PlasmoCSConfig = {
   matches: ["https://tools.swfz.io/document-pinp-react-portal"],
@@ -24,18 +20,17 @@ export const config: PlasmoCSConfig = {
 
 let observer = { disconnect: () => {} }
 
-const initialHandler = async (
-  message: ContentRequestBody<StreamerContentParams>,
-  _: chrome.runtime.MessageSender,
-  sendResponse: (response?: WorkerResponseBody) => void
+const initialHandler: PlasmoMessaging.Handler = async (
+  req,
+  res: PlasmoMessaging.Response<WorkerResponseBody>
 ) => {
   const storage = new Storage({ area: "local" })
   const config = (await storage.get<Config>("config")) || defaultConfig
 
-  if (hasLoadParams(message)) {
+  if (hasLoadParams(req)) {
     const boxElement = exampleExtractor.boxElementFn()
     if (boxElement === null || boxElement === undefined) {
-      sendResponse({ error: "Please start in presentation mode." })
+      res.send({ error: "Please start in presentation mode." })
       return
     }
 
@@ -46,7 +41,7 @@ const initialHandler = async (
         role: "handler",
         action: "connect",
         service: "example",
-        tabId: message.tabId
+        tabId: req.tabId
       }
     }).catch((e) => {
       console.warn(e)
@@ -70,26 +65,26 @@ const initialHandler = async (
           role: "subscriber",
           action: "connect",
           service: "example",
-          tabId: message.tabId
+          tabId: req.tabId
         }
       }).catch((e) => {
         console.warn(e)
       })
-      sendResponse({ message: "Subscribed page number in slide" })
+      res.send({ message: "Subscribed page number in slide" })
     } else {
-      sendResponse({ message: "Connected example site" })
+      res.send({ message: "Connected example site" })
     }
   }
 
-  if (hasSubscribeParams(message)) {
+  if (hasSubscribeParams(req)) {
     const boxElement = exampleExtractor.boxElementFn()
     if (boxElement === null || boxElement === undefined) {
-      sendResponse({ error: "Not found slide element..." })
+      res.send({ error: "Not found slide element..." })
       return
     }
 
-    render(boxElement, config, message.body?.comments || [])
-    sendResponse({ message: "comments rendered" })
+    render(boxElement, config, req.body?.comments || [])
+    res.send({ message: "comments rendered" })
   }
 }
 
@@ -97,7 +92,6 @@ batchInitialize([
   { feature: "comment", role: "handler" },
   { feature: "selfpost", role: "subscriber" }
 ])
-chrome.runtime.onMessage.addListener(initialHandler)
+listen(initialHandler)
 
-console.log("lasterror", chrome.runtime.lastError)
 console.log("loaded. content script.")

--- a/src/contents/googleslide.ts
+++ b/src/contents/googleslide.ts
@@ -26,7 +26,7 @@ let observer = { disconnect: () => {} }
 
 const initialHandler = async (
   message: ContentRequestBody<StreamerContentParams>,
-  sender: chrome.runtime.MessageSender,
+  _: chrome.runtime.MessageSender,
   sendResponse: (response?: WorkerResponseBody) => void
 ) => {
   const storage = new Storage({ area: "local" })

--- a/src/contents/googleslide.ts
+++ b/src/contents/googleslide.ts
@@ -8,7 +8,7 @@ import { batchInitialize } from "~src/lib/initializer"
 import { subscribePageNumber } from "~src/lib/poster"
 import { render } from "~src/lib/streamer"
 import { defaultConfig } from "~src/options"
-import { isLoadParams, isSubscribeParams } from "~src/types/guards"
+import { hasLoadParams, hasSubscribeParams } from "~src/types/guards"
 import {
   Config,
   ContentRequestBody,
@@ -32,7 +32,7 @@ const initialHandler = async (
   const storage = new Storage({ area: "local" })
   const config = (await storage.get<Config>("config")) || defaultConfig
 
-  if (isLoadParams(message)) {
+  if (hasLoadParams(message)) {
     const boxElement = googleslideExtractor.boxElementFn()
 
     if (boxElement === null || boxElement === undefined) {
@@ -82,7 +82,7 @@ const initialHandler = async (
     }
   }
 
-  if (isSubscribeParams(message)) {
+  if (hasSubscribeParams(message)) {
     const boxElement = googleslideExtractor.boxElementFn()
 
     // TODO: iframe内にコンテンツを差し込んでいるためkeyframesの記述を設定したCSSもIframeから読めないとanimationが動作しない
@@ -102,7 +102,8 @@ const initialHandler = async (
       return
     }
 
-    render(boxElement, config, message.comments)
+    const comments = message.body?.comments || []
+    render(boxElement, config, comments)
     sendResponse({ message: "comments rendered" })
   }
 }

--- a/src/contents/slack.ts
+++ b/src/contents/slack.ts
@@ -20,7 +20,7 @@ export const config: PlasmoCSConfig = {
 }
 const initialHandler = async (
   message: ContentRequestBody<PosterContentParams>,
-  sender: chrome.runtime.MessageSender,
+  _: chrome.runtime.MessageSender,
   sendResponse: (response?: WorkerResponseBody) => void
 ) => {
   // console.warn("req", req)

--- a/src/contents/slack.ts
+++ b/src/contents/slack.ts
@@ -5,7 +5,7 @@ import { sendToBackground } from "@plasmohq/messaging"
 import { slackExtractor, slackSelfPost } from "~src/lib/extractor/slack"
 import { batchInitialize } from "~src/lib/initializer"
 import { subscribeComments } from "~src/lib/subscriber"
-import { isLoadParams, isSakuraCommentParams } from "~src/types/guards"
+import { hasLoadParams, hasSakuraCommentParams } from "~src/types/guards"
 import {
   ContentRequestBody,
   PosterContentParams,
@@ -25,7 +25,7 @@ const initialHandler = async (
 ) => {
   // console.warn("req", req)
   // console.warn("res", res)
-  if (isLoadParams(message)) {
+  if (hasLoadParams(message)) {
     const observeElement = slackExtractor.listNodeExtractFn()
     if (observeElement === null || observeElement === undefined) {
       sendResponse({ error: "Subscribe node not found. please open chat list" })
@@ -62,8 +62,8 @@ const initialHandler = async (
     sendResponse({ message: "Subscribed comment list in chat." })
   }
 
-  if (isSakuraCommentParams(message)) {
-    const m = await slackSelfPost(message.comment)
+  if (hasSakuraCommentParams(message)) {
+    const m = await slackSelfPost(message.body?.comment || "")
     sendResponse(m)
   }
 }

--- a/src/contents/zoom.ts
+++ b/src/contents/zoom.ts
@@ -5,7 +5,7 @@ import { sendToBackground } from "@plasmohq/messaging"
 import { zoomExtractor, zoomSelfPost } from "~src/lib/extractor/zoom"
 import { batchInitialize } from "~src/lib/initializer"
 import { subscribeComments } from "~src/lib/subscriber"
-import { isLoadParams, isSakuraCommentParams } from "~src/types/guards"
+import { hasLoadParams, hasSakuraCommentParams } from "~src/types/guards"
 import {
   ContentRequestBody,
   PosterContentParams,
@@ -24,7 +24,7 @@ const initialHandler = async (
   _: chrome.runtime.MessageSender,
   sendResponse: (response?: WorkerResponseBody) => void
 ) => {
-  if (isLoadParams(message)) {
+  if (hasLoadParams(message)) {
     const observeElement = zoomExtractor.listNodeExtractFn()
 
     if (observeElement === null || observeElement === undefined) {
@@ -62,8 +62,8 @@ const initialHandler = async (
     sendResponse({ message: "Subscribed comment list in chat." })
   }
 
-  if (isSakuraCommentParams(message)) {
-    const m = await zoomSelfPost(message.comment)
+  if (hasSakuraCommentParams(message)) {
+    const m = await zoomSelfPost(message.body?.comment || "")
     sendResponse(m)
   }
 }

--- a/src/contents/zoom.ts
+++ b/src/contents/zoom.ts
@@ -21,7 +21,7 @@ export const config: PlasmoCSConfig = {
 
 const initialHandler = async (
   message: ContentRequestBody<PosterContentParams>,
-  sender: chrome.runtime.MessageSender,
+  _: chrome.runtime.MessageSender,
   sendResponse: (response?: WorkerResponseBody) => void
 ) => {
   if (isLoadParams(message)) {

--- a/src/lib/subscriber.ts
+++ b/src/lib/subscriber.ts
@@ -19,10 +19,11 @@ const subscribeComments = (
       .filter((node) => node !== undefined)
 
     const comments = Array.from(nodes)
-      .map((node) => extractors[service].commentExtractFn(node))
+      .filter((node) => node !== undefined)
+      .map((node) => extractors[service].commentExtractFn(node as Node))
       .filter((c) => c !== undefined && c !== null)
 
-    return comments
+    return comments as string[]
   }
 
   const observer = new MutationObserver(async function (

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -42,7 +42,7 @@ function IndexPopup() {
     }
 
     const res = await sendToContentScript({
-      action: "Load",
+      name: "Load",
       tabId: tab.id
     })
 

--- a/src/sidepanel.tsx
+++ b/src/sidepanel.tsx
@@ -9,7 +9,7 @@ import "./style.css"
 import { Play } from "lucide-react"
 
 import { detectService, serviceToHandlerFeature } from "~src/lib/service"
-import { Feature } from "~src/types/types"
+import { Feature, LoadParams } from "~src/types/types"
 
 import Alert from "./components/alert"
 import ExtHeader from "./components/header"
@@ -41,8 +41,8 @@ function IndexSidepanel() {
       return
     }
 
-    const res = await sendToContentScript({
-      action: "Load",
+    const res = await sendToContentScript<LoadParams>({
+      name: "Load",
       tabId: tab.id
     })
 

--- a/src/types/guards.ts
+++ b/src/types/guards.ts
@@ -1,19 +1,12 @@
-import {
-  ContentMessagebase,
-  LoadParams,
-  SakuraCommentParams,
-  SubscribeParams
-} from "./types"
+import { PlasmoMessaging } from "@plasmohq/messaging"
 
-function createContentScriptTypeGuard<T extends ContentMessagebase>(
-  actionType: T["action"]
-) {
-  return (message: ContentMessagebase): message is T =>
-    message.action === actionType
+import { LoadParams, SakuraCommentParams, SubscribeParams } from "./types"
+
+const hasParams = <T extends PlasmoMessaging.Request>(name: T["name"]) => {
+  return (message: PlasmoMessaging.Request): message is T =>
+    message.name === name
 }
-
-export const isLoadParams = createContentScriptTypeGuard<LoadParams>("Load")
-export const isSubscribeParams =
-  createContentScriptTypeGuard<SubscribeParams>("Subscribe")
-export const isSakuraCommentParams =
-  createContentScriptTypeGuard<SakuraCommentParams>("SakuraComment")
+export const hasLoadParams = hasParams<LoadParams>("Load")
+export const hasSubscribeParams = hasParams<SubscribeParams>("Subscribe")
+export const hasSakuraCommentParams =
+  hasParams<SakuraCommentParams>("SakuraComment")

--- a/src/types/guards.ts
+++ b/src/types/guards.ts
@@ -1,0 +1,19 @@
+import {
+  ContentMessagebase,
+  LoadParams,
+  SakuraCommentParams,
+  SubscribeParams
+} from "./types"
+
+function createContentScriptTypeGuard<T extends ContentMessagebase>(
+  actionType: T["action"]
+) {
+  return (message: ContentMessagebase): message is T =>
+    message.action === actionType
+}
+
+export const isLoadParams = createContentScriptTypeGuard<LoadParams>("Load")
+export const isSubscribeParams =
+  createContentScriptTypeGuard<SubscribeParams>("Subscribe")
+export const isSakuraCommentParams =
+  createContentScriptTypeGuard<SakuraCommentParams>("SakuraComment")

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -78,6 +78,34 @@ export interface RequestBody {
   comment?: string
 }
 
+export type ContentMessagebase = {
+  action: "Load" | "Subscribe" | "SakuraComment"
+}
+
+export type LoadParams = {
+  tabId: number
+} & ContentMessagebase
+
+export type SakuraCommentParams = {
+  comment: string
+} & ContentMessagebase
+
+export type SubscribeParams = {
+  comments: string[]
+} & ContentMessagebase
+
+export type StreamerContentParams = LoadParams | SubscribeParams
+export type PosterContentParams = LoadParams | SakuraCommentParams
+
+type ActionMap = {
+  Load: LoadParams
+  Subscribe: SubscribeParams
+  SakuraComment: SakuraCommentParams
+}
+
+export type ContentRequestBody<T extends ContentMessagebase> =
+  T["action"] extends keyof ActionMap ? ActionMap[T["action"]] : never
+
 export type BackgroundWorker = "connector" | "forwarder"
 
 export interface WorkerResponseBody {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -124,7 +124,7 @@ export interface CommentExtractor {
 }
 
 export interface SlideExtractor {
-  boxElementFn: () => HTMLElement | null | undefined
+  boxElementFn: () => HTMLDivElement | null | undefined
   pageNumberElementFn: () => HTMLElement | null | undefined
 }
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,3 +1,5 @@
+import { PlasmoMessaging } from "@plasmohq/messaging"
+
 export type Role = "subscriber" | "handler"
 export type Feature = "comment" | "selfpost"
 
@@ -78,21 +80,15 @@ export interface RequestBody {
   comment?: string
 }
 
-export type ContentMessagebase = {
-  action: "Load" | "Subscribe" | "SakuraComment"
-}
-
-export type LoadParams = {
-  tabId: number
-} & ContentMessagebase
-
-export type SakuraCommentParams = {
-  comment: string
-} & ContentMessagebase
-
-export type SubscribeParams = {
-  comments: string[]
-} & ContentMessagebase
+export type LoadParams = PlasmoMessaging.Request<"Load", {}>
+export type SakuraCommentParams = PlasmoMessaging.Request<
+  "SakuraComment",
+  { comment: string }
+>
+export type SubscribeParams = PlasmoMessaging.Request<
+  "Subscribe",
+  { comments: string[] }
+>
 
 export type StreamerContentParams = LoadParams | SubscribeParams
 export type PosterContentParams = LoadParams | SakuraCommentParams
@@ -103,8 +99,10 @@ type ActionMap = {
   SakuraComment: SakuraCommentParams
 }
 
-export type ContentRequestBody<T extends ContentMessagebase> =
-  T["action"] extends keyof ActionMap ? ActionMap[T["action"]] : never
+export type ContentRequestBody<T extends PlasmoMessaging.Request> =
+  T["name"] extends keyof ActionMap
+    ? PlasmoMessaging.Request<T["name"], ActionMap[T["name"]]>
+    : PlasmoMessaging.Request
 
 export type BackgroundWorker = "connector" | "forwarder"
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -51,8 +51,6 @@ export type ContentToBackgroundBody = {
 // forwarder name, body
 export type ForwarderRequestBody = {
   action: "SakuraComment" | "Subscribe"
-  comment?: string
-  comments?: string[]
 }
 
 type ConnectorAction = "connect" | "disconnect"
@@ -141,4 +139,11 @@ export type SelfpostConfig = {
     seconds: number
     comment: string
   }[]
+}
+
+declare module "@plasmohq/messaging" {
+  interface MessagesMetadata {
+    // SakuraComment: { comment: string }
+    // Subscribe: [comments: string[]]
+  }
 }


### PR DESCRIPTION
5363cc5 feat: FWの推奨する使い方ではなかったためchrome拡張のメッセージングに戻した
33cdd88 fix: typecheck
6fc844d fix: type cast
0c4dde1 feat: Messagingのやり取りをPlasmoMessagingの形式に合わせた
6509edb fix: sendResponseが動かなくなってしまったのでPlasmoのメソッドを使うように戻した